### PR TITLE
Fix build on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ moodbar = static_library('moodbar',
   dependencies : [
     dependency('glib-2.0'),
     dep_gstreamer,
+    dependency('gstreamer-plugins-base-1.0'),
   ],
 )
 


### PR DESCRIPTION
`gstreamer-plugins-base-1.0` is a special dependency. On macOS using Homebrew, it needs to be explicitly added as dependency so that the includes will be found. Otherwise it will fail with:

```
../gst/moodbar/gstfastspectrum.h:36:10: fatal error: 'gst/audio/gstaudiofilter.h' file not found
```